### PR TITLE
Private Key Support (Optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Make sure to replace `<path to dist/index.js>` with the path to the `dist/index.
       "command": "node",
       "args": ["<path to dist/index.js>"],
       "env": {
-        "AKASH_MNEMONIC": "<your mnemonic here>",
+        "AKASH_MNEMONIC": "<your mnemonic here>", // OR "AKASH_PRIVATE_KEY": "<your 64-character-hex-string>"
         "AKASH_RPC_URL": "https://rpc.akashnet.net:443" // optional, defaults to https://rpc.akashnet.net:443
       }
     }

--- a/src/AkashMCP.ts
+++ b/src/AkashMCP.ts
@@ -1,4 +1,4 @@
-import type { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
+import type { DirectSecp256k1HdWallet, DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import type { SigningStargateClient } from '@cosmjs/stargate';
 import { loadWalletAndClient, loadCertificate } from './utils/index.js';
 import { SERVER_CONFIG } from './config.js';
@@ -22,7 +22,7 @@ import type { ToolContext } from './types/index.js';
 import type { CertificatePem } from '@akashnetwork/akashjs/build/certificates/certificate-manager/CertificateManager.js';
 
 class AkashMCP extends McpServer {
-  private wallet: DirectSecp256k1HdWallet | null = null;
+  private wallet: DirectSecp256k1HdWallet | DirectSecp256k1Wallet | null = null;
   private client: SigningStargateClient | null = null;
   private certificate: CertificatePem | null = null;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export const SERVER_CONFIG = {
   environment: process.env.NODE_ENV || 'development',
   rpcEndpoint: process.env.RPC_ENDPOINT || 'https://rpc.akashnet.net:443',
   mnemonic: process.env.AKASH_MNEMONIC || '',
+  privateKey: process.env.AKASH_PRIVATE_KEY || '',
 } as const;
 
 export type ServerConfig = typeof SERVER_CONFIG;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,13 +1,13 @@
 import type { z } from 'zod';
 import type { SigningStargateClient } from '@cosmjs/stargate';
-import type { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
+import type { DirectSecp256k1HdWallet, DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import type { ReadResourceCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CertificatePem } from '@akashnetwork/akashjs/build/certificates/certificate-manager/CertificateManager.js';
 
 // Tool related types
 export interface ToolContext {
   client: SigningStargateClient;
-  wallet: DirectSecp256k1HdWallet;
+  wallet: DirectSecp256k1HdWallet | DirectSecp256k1Wallet;
   certificate: CertificatePem;
 }
 

--- a/src/utils/load-certificate.ts
+++ b/src/utils/load-certificate.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import * as cert from '@akashnetwork/akashjs/build/certificates/index.js';
 import { certificateManager } from '@akashnetwork/akashjs/build/certificates/certificate-manager/index.js';
-import type { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
+import type { DirectSecp256k1HdWallet, DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import type { SigningStargateClient } from '@cosmjs/stargate';
 import type { CertificatePem } from '@akashnetwork/akashjs/build/certificates/certificate-manager/CertificateManager.js';
 
@@ -11,7 +11,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export async function loadCertificate(
-  wallet: DirectSecp256k1HdWallet,
+  wallet: DirectSecp256k1HdWallet | DirectSecp256k1Wallet,
   client: SigningStargateClient
 ): Promise<CertificatePem> {
   const accounts = await wallet.getAccounts();

--- a/src/utils/load-wallet.ts
+++ b/src/utils/load-wallet.ts
@@ -1,12 +1,22 @@
 import { GasPrice, SigningStargateClient } from '@cosmjs/stargate';
 import { getAkashTypeRegistry } from '@akashnetwork/akashjs/build/stargate/index.js';
-import { DirectSecp256k1HdWallet, Registry } from '@cosmjs/proto-signing';
+import { DirectSecp256k1HdWallet, DirectSecp256k1Wallet, Registry } from '@cosmjs/proto-signing';
 import { SERVER_CONFIG } from '../config.js';
 
 export async function loadWalletAndClient() {
-  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(SERVER_CONFIG.mnemonic, {
-    prefix: 'akash',
-  });
+  let wallet: DirectSecp256k1HdWallet | DirectSecp256k1Wallet;
+  
+  if (SERVER_CONFIG.privateKey) {
+    const privateKeyBytes = Uint8Array.from(Buffer.from(SERVER_CONFIG.privateKey, 'hex'));
+    wallet = await DirectSecp256k1Wallet.fromKey(privateKeyBytes, 'akash');
+  } else if (SERVER_CONFIG.mnemonic) {
+    wallet = await DirectSecp256k1HdWallet.fromMnemonic(SERVER_CONFIG.mnemonic, {
+      prefix: 'akash',
+    });
+  } else {
+    throw new Error('Either AKASH_MNEMONIC or AKASH_PRIVATE_KEY must be provided');
+  }
+
   const registry = getAkashTypeRegistry();
 
   const client = await SigningStargateClient.connectWithSigner(SERVER_CONFIG.rpcEndpoint, wallet, {

--- a/src/utils/load-wallet.ts
+++ b/src/utils/load-wallet.ts
@@ -6,13 +6,13 @@ import { SERVER_CONFIG } from '../config.js';
 export async function loadWalletAndClient() {
   let wallet: DirectSecp256k1HdWallet | DirectSecp256k1Wallet;
   
-  if (SERVER_CONFIG.privateKey) {
-    const privateKeyBytes = Uint8Array.from(Buffer.from(SERVER_CONFIG.privateKey, 'hex'));
-    wallet = await DirectSecp256k1Wallet.fromKey(privateKeyBytes, 'akash');
-  } else if (SERVER_CONFIG.mnemonic) {
+  if (SERVER_CONFIG.mnemonic) {
     wallet = await DirectSecp256k1HdWallet.fromMnemonic(SERVER_CONFIG.mnemonic, {
       prefix: 'akash',
     });
+  } else if (SERVER_CONFIG.privateKey) {
+    const privateKeyBytes = Uint8Array.from(Buffer.from(SERVER_CONFIG.privateKey, 'hex'));
+    wallet = await DirectSecp256k1Wallet.fromKey(privateKeyBytes, 'akash');
   } else {
     throw new Error('Either AKASH_MNEMONIC or AKASH_PRIVATE_KEY must be provided');
   }


### PR DESCRIPTION
# Add Private Key Authentication Support

## Description
This PR adds support for private key authentication as an alternative to mnemonic-based authentication for the Akash MCP server. Users can now authenticate using either a mnemonic phrase or a raw private key, providing more flexibility in wallet management and integration scenarios.

## Motivation
Current implementation only supports mnemonic-based authentication via `AKASH_MNEMONIC`. This enhancement addresses several use cases:
- **Production Deployments**: Many production systems manage raw private keys rather than mnemonics
- **Security Preferences**: Some users prefer managing private keys directly
- **Integration**: Easier integration with existing infrastructure that uses private key authentication
- **Automation**: Simplified automated deployments and CI/CD pipelines

## Changes

### Modified Files (5 total):
1. **src/config.ts** - Added `privateKey` configuration field
2. **src/utils/load-wallet.ts** - Implemented private key authentication logic
3. **src/utils/load-certificate.ts** - Updated type signatures to support both wallet types
4. **src/types/index.ts** - Updated `ToolContext` interface types
5. **src/AkashMCP.ts** - Updated wallet property types

### Key Features:
- ✅ Support for hex-encoded private key authentication
- ✅ Automatic selection between private key and mnemonic methods
- ✅ Clear error messaging when neither authentication method is provided
- ✅ Full backward compatibility with existing mnemonic authentication
- ✅ Type-safe implementation using union types

## Technical Implementation

### Authentication Priority:
1. Check for `AKASH_MNEMONIC` environment variable
2. If not present, check for `AKASH_PRIVATE_KEY` environment variable
3. Throw error if neither is provided

### Type System:
Uses union types (`DirectSecp256k1HdWallet | DirectSecp256k1Wallet`) to maintain type safety while supporting both authentication methods. Both wallet types implement compatible interfaces for signing and account management.

### Private Key Format:
- Expected: Hex string (64 characters, 32 bytes)
- Example: `e4b1c2d3a5f60798b2e1f3c4d5a6b7c8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4`
- Automatically converted to `Uint8Array` for wallet initialization

## Testing

### Manual Testing:
- ✅ Successfully initialized MCP server with private key authentication
- ✅ Verified private key authentication flow: `Using privateKey authentication for Akash`
- ✅ MCP server starts without errors
- ✅ Akash adapter initializes successfully
- ✅ All dependent services initialize properly
- ✅ Verified backward compatibility with mnemonic authentication

### Test Environment:
- Node.js v18.19.1
- @cosmjs/proto-signing v0.32.4
- Production deployment environment

## Backward Compatibility
- ✅ **No Breaking Changes**: Existing mnemonic authentication continues to work unchanged
- ✅ **Default Behavior Preserved**: When only mnemonic is provided, existing behavior is maintained
- ✅ **Graceful Degradation**: Clear error messages guide users when configuration is missing

## Environment Variables

### New:
```bash
AKASH_PRIVATE_KEY  # Optional: Hex-encoded private key (32 bytes/64 chars)
```

### Usage Examples:
```bash
# Option 1: Using private key (NEW)
export AKASH_PRIVATE_KEY="e4b1c2d3a5f60798b2e1f3c4d5a6b7c8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4"

# Option 2: Using mnemonic (EXISTING)
export AKASH_MNEMONIC="word1 word2 word3 ... word24"
```

## Dependencies
- ✅ No new dependencies added
- ✅ Uses existing `@cosmjs/proto-signing` package
- ✅ No version bumps required

## Checklist
- [x] Code follows project conventions
- [x] Changes are backward compatible
- [x] No breaking changes to existing functionality
- [x] Manual testing completed successfully
- [x] All modified files included in PR
- [x] Clear description of changes provided
- [x] Type definitions updated

## Related Issues
N/A - Enhancement for authentication flexibility

## Additional Notes
This implementation prioritizes mnemonic authentication over private key when both are provided.